### PR TITLE
#1198 read /dev/urandom for session id generation

### DIFF
--- a/build/platform-core/start_platform_core.sh
+++ b/build/platform-core/start_platform_core.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 mkdir -p /log
-java -jar /application/platform-core.jar  --server.address=0.0.0.0 --server.port=8080 \
+java -Djava.security.egd=file:/dev/urandom -jar /application/platform-core.jar  --server.address=0.0.0.0 --server.port=8080 \
 --spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver \
 --spring.datasource.url=jdbc:mysql://${MYSQL_SERVER_ADDR}:${MYSQL_SERVER_PORT}/${MYSQL_SERVER_DATABASE_NAME}?serverTimezone=Asia\/Shanghai\&characterEncoding=utf8 \
 --spring.datasource.username=${MYSQL_USER_NAME} \


### PR DESCRIPTION
/dev/random的random依赖于系统中断，因此在系统的中断数不足时，/dev/random设备会一直封锁，尝试读取的进程就会进入等待状态，直到系统的中断数充分够用, /dev/random设备可以保证数据的随机性。
/dev/urandom不依赖系统的中断，也就不会造成进程忙等待，但是数据的随机性也相对不高